### PR TITLE
Start from any scene

### DIFF
--- a/Overworld/OverworldManager.gd
+++ b/Overworld/OverworldManager.gd
@@ -17,13 +17,28 @@ class_name OverworldManager
 func _ready():
 	print("Overworld Ready Start")
 	super()
+
+	var start_room: Room = find_start_room()
+
+	# wait for all other nodes to be ready, then continue
+	await $/root.ready
 	
 	stageUI = $CanvasLayer/OW_UI
 	
 	stageUI.initialize(self)
-	overworldWorld.initialize(self)
+	overworldWorld.initialize(self, start_room)
 	cutsceneManager.stageManager = self
 	
 	var overworldGameState = GameState_Overworld.new()	#Adds itself to GameStateStack
 	
 	print("Overworld Ready Finish")
+
+
+# Scan the root-level nodes to see if the game has a valid room.
+func find_start_room() -> Room:
+	for node: Node in $/root.get_children():
+		if node is Room:
+			return node
+
+	printerr("Game started in a scene that is not a room! Can't initialize global info.")
+	return null

--- a/Overworld/World/World.gd
+++ b/Overworld/World/World.gd
@@ -11,15 +11,15 @@ var currentRoom
 
 func _ready():
 	print("World Ready Start")
-	for child in get_children():
-		if child is Room:
-			currentRoom = child
-		else:
-			printerr("No room scene")
 	print("World Ready Finish")
 
-func initialize(om: OverworldManager):
+func initialize(om: OverworldManager, cr: Room):
 	owManager = om
+
+	currentRoom = cr
+	cr.reparent(self)
+	cr.set_owner(self)
+	
 	DialogueSystem.updateOWVars(owManager.stageUI, self)	#Update before room. Actors use for spawn flags
 	currentRoom.initialize(om)
 

--- a/Overworld/overworld.tscn
+++ b/Overworld/overworld.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=14 format=3 uid="uid://wf85spc1lhaa"]
+[gd_scene load_steps=13 format=3 uid="uid://wf85spc1lhaa"]
 
 [ext_resource type="Script" path="res://Overworld/UI/OW_UI.gd" id="1_4a7eq"]
 [ext_resource type="Script" path="res://Overworld/OverworldManager.gd" id="1_flynd"]
 [ext_resource type="Script" path="res://Overworld/World/World.gd" id="2_fscot"]
 [ext_resource type="PackedScene" uid="uid://bkgsrieys8sap" path="res://Overworld/UI/PlayerUI_World.tscn" id="3_6b10h"]
 [ext_resource type="Script" path="res://Battle/UI/PlayerAnchors.gd" id="3_co72e"]
-[ext_resource type="PackedScene" uid="uid://cjv1mcuglg2br" path="res://Overworld/Rooms/StartRoom.tscn" id="6_map7u"]
 [ext_resource type="AudioStream" uid="uid://d4gp1tjc4uixo" path="res://Audio/Tundra.mp3" id="12_exalw"]
 [ext_resource type="Script" path="res://Cutscenes/CutsceneManager.gd" id="23_dssid"]
 
@@ -338,8 +337,6 @@ text = "[font_size=75][center]Your goal lies further ahead...[/center][/font_siz
 y_sort_enabled = true
 script = ExtResource("2_fscot")
 metadata/_edit_lock_ = true
-
-[node name="StartRoom" parent="World" instance=ExtResource("6_map7u")]
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="World"]
 stream = ExtResource("12_exalw")

--- a/project.godot
+++ b/project.godot
@@ -11,7 +11,7 @@ config_version=5
 [application]
 
 config/name="RPG Foundation"
-run/main_scene="res://game.tscn"
+run/main_scene="res://Overworld/Rooms/StartRoom.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://Art/icon.svg"
 
@@ -25,6 +25,7 @@ FlagManager="*res://Flags/FlagManager.gd"
 InputManager="*res://InputManager.gd"
 MultiplayerInput="*res://addons/multiplayer_input/multiplayer_input.gd"
 PhantomCameraManager="*res://addons/phantom_camera/scripts/managers/phantom_camera_manager.gd"
+Game="*res://game.tscn"
 
 [display]
 


### PR DESCRIPTION
* Added logic to `OverworldManager` to detect if the game was started from a `Room`, and initialize core systems using that room
* Updated `World.initialize()` to take in the starting room
* Added `Game.tscn` to the Globals list
* Removed StartRoom from Overworld scene